### PR TITLE
Fix bug with makefile after make test has been run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,13 @@ CFLAGS := -Wall -Werror -Wshadow -Wextra -Wno-unused-parameter -std=gnu11 -ggdb3
 LDFLAGS := -rdynamic -pthread -lncursesw -lutil -ldl
 
 OBJDIR ?= build
+DESTDIR ?= /usr/local/bin
 
-.PHONY: all clean
+.PHONY: all clean install
 
-all: ce
+EXE := ce
+
+all: $(EXE)
 
 TEST_CSRCS := $(wildcard test_*.c)
 TESTS := $(patsubst %.c,%,$(TEST_CSRCS))
@@ -22,7 +25,7 @@ $(OBJDIR):
 $(OBJDIR)/%.o: %.c $(CHDRS) | $(OBJDIR)
 	$(CC) $(CFLAGS) -c  -o $@ $<
 
-ce: $(COBJS)
+$(EXE): $(COBJS)
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 test: $(TESTS)
@@ -32,5 +35,8 @@ test_%: test_%.c $(OBJDIR)/%.o
 	./$@
 
 clean:
-	rm -f ce $(TESTS) ce_test.log valgrind.out
+	rm -f $(EXE) $(TESTS) ce_test.log valgrind.out
 	rm -rf $(OBJDIR)
+
+install:
+	install -D $(EXE) $(DESTDIR)/$(EXE)

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,10 @@ OBJDIR ?= build
 
 all: ce
 
-CSRCS := $(shell ls *.c | grep -v test_*)
+TEST_CSRCS := $(wildcard test_*.c)
+TESTS := $(patsubst %.c,%,$(TEST_CSRCS))
+
+CSRCS := $(filter-out $(TEST_CSRCS), $(wildcard *.c))
 # put our .o files in $(OBJDIR)
 COBJS := $(patsubst %.c,$(OBJDIR)/%.o,$(CSRCS))
 CHDRS := $(wildcard *.h)
@@ -22,11 +25,12 @@ $(OBJDIR)/%.o: %.c $(CHDRS) | $(OBJDIR)
 ce: $(COBJS)
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
-test: test_ce
-test_ce: test_ce.c ce.c
+test: $(TESTS)
+
+test_%: test_%.c $(OBJDIR)/%.o
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
-	./test_ce
+	./$@
 
 clean:
-	rm -f ce test_ce ce_test.log valgrind.out
+	rm -f ce $(TESTS) ce_test.log valgrind.out
 	rm -rf $(OBJDIR)


### PR DESCRIPTION
- grep command was malfunctioning once the file test_ce had been created
- Generalize make test to create a test executable and run it for each
  file named test_<module>.c . For example: test_ce_vim.c would build
  test_ce_vim and link against ce_vim.o
- use the pre-built object file from make when running make test. don't
  rebuild it if you don't need to